### PR TITLE
(1) ras-common to 0.2.26 master branch and upping api-gateway version…

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -86,7 +86,7 @@ enable_registration = false
 ;
 ;   Values to be shown in /info (the healthcheck endpoint)
 ;
-version = 0.0.1
+version = 0.1.0
 name = apigatewaysvc
 ;
 ;   Environments ::

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ONSdigital/ras-common.git@TBLXXX/cfenv#0.2.23
+git+https://github.com/ONSdigital/ras-common.git@0.2.26
 arrow==0.10.0
 asn1crypto==0.22.0
 attrs==17.2.0


### PR DESCRIPTION
… to 0.1.0

This is ensuring the api-gateway uses the master branch 0.2.26 tagged version of ras-common. I've tested this locally and all working ok.